### PR TITLE
Use StringBuilder to build exports path

### DIFF
--- a/src/pro/javacard/ant/JavaCard.java
+++ b/src/pro/javacard/ant/JavaCard.java
@@ -498,12 +498,13 @@ public class JavaCard extends Task {
 					exps.add(Paths.get(imp.exps).toAbsolutePath().toString());
 				}
 				// StringJoiner is 1.8+, we are 1.7+
-				String expstring = "";
+				StringBuilder expstringbuilder = new StringBuilder();
 				for (String imp : exps) {
-					expstring = expstring + File.pathSeparatorChar + imp;
+					expstringbuilder.append(File.pathSeparatorChar);
+					expstringbuilder.append(imp);
 				}
 
-				j.createArg().setLine("-exportpath '" + expstring + "'");
+				j.createArg().setLine("-exportpath '" + expstringbuilder.toString() + "'");
 				j.createArg().setLine("-verbose");
 				j.createArg().setLine("-nobanner");
 				if (debug) {


### PR DESCRIPTION
Use of multiple appends to a String is a discouraged way to build a
String.

Signed-off-by: Dmitry Eremin-Solenikov <dbaryshkov@gmail.com>