### PR TITLE
Incorrect javac options

### DIFF
--- a/src/pro/javacard/ant/JavaCard.java
+++ b/src/pro/javacard/ant/JavaCard.java
@@ -405,9 +405,8 @@ public class JavaCard extends Task {
 			}
 
 			j.setDestdir(tmp);
-			if (debug) {
-				j.setDebug(true);
-			}
+			j.setDebug(true);
+			j.setDebugLevel("lines,vars,source");
 			if (jckit.version == JC.V212) {
 				j.setTarget("1.1");
 				j.setSource("1.1");

--- a/src/pro/javacard/ant/JavaCard.java
+++ b/src/pro/javacard/ant/JavaCard.java
@@ -412,7 +412,7 @@ public class JavaCard extends Task {
 				j.setSource("1.1");
 				// Always set debug to disable "contains local variables,
 				// but not local variable table." messages
-				j.setDebug(true);
+				//j.setDebug(true);
 			} else if (jckit.version == JC.V221) {
 				j.setTarget("1.2");
 				j.setSource("1.2");


### PR DESCRIPTION
Ant appends "-g:none" by default. "-g:lines,vars,source" is a mandatory field for javac since debug information in the class file is used by the convertor