### PR TITLE
-> added double quote sign to prevent white-space error when verifying

### DIFF
--- a/src/pro/javacard/ant/JavaCard.java
+++ b/src/pro/javacard/ant/JavaCard.java
@@ -639,7 +639,7 @@ public class JavaCard extends Task {
 										throws IOException
 								{
 									if (file.toString().endsWith(".exp")) {
-										expfiles.add(file.toAbsolutePath().toString());
+										expfiles.add('"' + file.toAbsolutePath().toString() + '"');
 									}
 									return FileVisitResult.CONTINUE;
 								}
@@ -656,7 +656,7 @@ public class JavaCard extends Task {
 					for (String exp: expfiles) {
 						j.createArg().setLine(exp);
 					}
-					j.createArg().setLine(getProject().resolveFile(output_cap).toString());
+					j.createArg().setLine('"' + getProject().resolveFile(output_cap).toString() + '"');
 					j.setFailonerror(true);
 					j.setFork(true);
 


### PR DESCRIPTION
I just added double quote sign on line 642 and 659 to make the cli thinks that the path is valid...