### PR TITLE
Javacard.cap.import alias added to avoid clashes with keyword

### DIFF
--- a/src/pro/javacard/ant/JavaCard.java
+++ b/src/pro/javacard/ant/JavaCard.java
@@ -275,6 +275,11 @@ public class JavaCard extends Task {
 			return imp;
 		}
 
+		/** Many imports inside one package - jimport to avoid conflict with gradle / groovy keyword */
+		public JCImport createJimport() {
+			return this.createImport();
+		}
+
 		// Check that arguments are sufficient and do some DWIM
 		private void check() {
 			JavaCardKit env = detectSDK(System.getenv("JC_HOME"));


### PR DESCRIPTION
## Summary

Javacard.cap.jimport has been added as an alias to Javacard.cap.import so the import directive can be defined in the Gradle. Grade groovy has import as a reserved keyword so it clashes with the configuration directive.

### Back story

I am building javacard caps with the Gradle using your great `ant-javacard` project. This keyword clash is the only thing blocking the build.

I kept the original `import` for the backward compatibility.

Take a look at:
https://github.com/ph4r05/javacard-gradle-template
