### PR TITLE
Fixing null parameter and split parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Details:
    * `aid` attribute - AID (hex) of the package. Recommended - or set to the 5 first bytes of the applet AID if left unspecified.
    * `output` attribute - path where to save the generated CAP file. Required.
    * `export` attribute - path (folder) where to place generated EXP file. Optional.
-   * `jaroutput` attribute - path (folder) where to place the JAR file. Optional.
+   * `jaroutput` attribute - path where to place the JAR file. Optional.
    * `jca` attribute - path where to save the generated JavaCard Assembly (JCA) file. Optional.
    * `verify` attribute - if set to false, disables verification of the resulting CAP file with offcardeverifier. Optional.
    * `debug` attribute - if set to true, generates debug CAP components. Optional.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Details:
    * `version` attribute - version of the package. Optional - defaults to 0.0 if left unspecified.
    * `aid` attribute - AID (hex) of the package. Recommended - or set to the 5 first bytes of the applet AID if left unspecified.
    * `output` attribute - path where to save the generated CAP file. Required.
-   * `export` attribtue - path (folder) where to place the JAR and generated EXP file. Optional.
+   * `export` attribute - path (folder) where to place generated EXP file. Optional.
+   * `jaroutput` attribute - path (folder) where to place the JAR file. Optional.
    * `jca` attribute - path where to save the generated JavaCard Assembly (JCA) file. Optional.
    * `verify` attribute - if set to false, disables verification of the resulting CAP file with offcardeverifier. Optional.
    * `debug` attribute - if set to true, generates debug CAP components. Optional.

--- a/src/pro/javacard/ant/JavaCard.java
+++ b/src/pro/javacard/ant/JavaCard.java
@@ -458,7 +458,6 @@ public class JavaCard extends Task {
 				{
 					cp.append(new Path(getProject(), i.jar));
 				}
-				cp.append(new Path(getProject(), i.jar));
 			}
 			j.execute();
 		}


### PR DESCRIPTION
- jar export is now into separate parameter which is "jaroutput", it is not into single "export" parameter which previously generate jar and exp

- fixing bug when the following case occurs: <import> tag contains single attributes only either exps or jar
	<javacard>
	  <cap jckit="${jckit211}" aid="0102030405" output="${dist}/${applet}-${DSTAMP}.cap" sources="${src}" export="${dist}" jca="${dist}/${applet}-${DSTAMP}.jca" jaroutput="${dist}/${applet}-${DSTAMP}.jar">
	    <applet class="com.sample.Class" aid="0102030405060708"/>
	  	<import jar="${lib}/test1.jar"/>
	  	<import jar="${lib}/test2.jar"/>
	  	<import exps="${build}"/>
	  </cap><javacard/>