### PR TITLE
Fixes for recent patch series

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Details:
    * `verify` attribute - if set to false, disables verification of the resulting CAP file with offcardeverifier. Optional.
    * `debug` attribute - if set to true, generates debug CAP components. Optional.
    * `ints` attribute - if set to true, enables support for 32 bit `int` type. Optional.
+   * `javaVersion` attribute - if set to true, override the Java source and target version. Optional.
  * `applet` tag - for creating an applet inside the CAP
    * `class` attribute - class of the Applet where install() method is defined. Required.
    * `aid` attribute - AID (hex) of the applet. Recommended - or set to package `aid`+`i` where `i` is index of the applet definition in the build.xml instruction

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Details:
    * `verify` attribute - if set to false, disables verification of the resulting CAP file with offcardeverifier. Optional.
    * `debug` attribute - if set to true, generates debug CAP components. Optional.
    * `ints` attribute - if set to true, enables support for 32 bit `int` type. Optional.
-   * `javaVersion` attribute - if set to true, override the Java source and target version. Optional.
+   * `javaversion` attribute - override the Java source and target version. Optional.
  * `applet` tag - for creating an applet inside the CAP
    * `class` attribute - class of the Applet where install() method is defined. Required.
    * `aid` attribute - AID (hex) of the applet. Recommended - or set to package `aid`+`i` where `i` is index of the applet definition in the build.xml instruction

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Sample:
 Details:
  * `javacard` tag - generic task
    * `jckit` attribute - path to the JavaCard SDK that is used if individual `cap` does not specify one. Optional if `cap` defines one, required otherwise.
+   * `javaversion` attribute - override the Java source and target version. Can be overridden for each `cap`. Optional.
  * `cap` tag - construct a CAP file
    * `jckit` attribute - path to the JavaCard SDK to be used for this CAP. Optional if `javacard` defines one, required otherwise. 
    * `sources` attribute - path to Java source code, to be compiled against the current JavaCard SDK. Either `sources` or `classes` is required.

--- a/src/main/java/pro/javacard/ant/JavaCard.java
+++ b/src/main/java/pro/javacard/ant/JavaCard.java
@@ -124,7 +124,7 @@ public class JavaCard extends Task {
         master_jckit_path = msg;
     }
 
-    public void setJavaVersion(String msg) {
+    public void setJavaversion(String msg) {
         master_java_version = msg;
     }
 
@@ -198,7 +198,7 @@ public class JavaCard extends Task {
             jckit_path = msg;
         }
 
-        public void setJavaVersion(String msg) {
+        public void setJavaversion(String msg) {
             java_version = msg;
         }
 

--- a/src/main/java/pro/javacard/ant/JavaCard.java
+++ b/src/main/java/pro/javacard/ant/JavaCard.java
@@ -584,11 +584,11 @@ public class JavaCard extends Task {
 
             // export files for verification
             for (File exp : expfiles) {
-                j.createArg().setLine(exp.toString());
+                j.createArg().setFile(exp);
             }
 
             // cap file for verification
-            j.createArg().setLine(project.resolveFile(output_cap).toString());
+            j.createArg().setFile(project.resolveFile(output_cap));
 
             // report the command
             log("command: " + j.getCommandLine(), Project.MSG_VERBOSE);


### PR DESCRIPTION
These two patches fix issues with my recent patch series.

The first patch fixes the "path with whitespace" issue, which was actually a quoting issue and unrelated to using java.util.File. Calling "setFile" instead of "setLine" solves the issue. All other calls to setLine have quoting in place that should prevent problems.

The second patch documents another option.
