### PR TITLE
Add javac includes and excludes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Details:
    * `sources` attribute - path to Java source code, to be compiled against the JavaCard SDK. Either `sources` or `classes` is required, unless `src/main/javacard` exists.
    * `sources2` attribute - additional sources to build per-platform applets. Optional.
    * `classes` attribute - path to pre-compiled class files to be assembled into a CAP file. If both `classes` and `sources` are specified, compiled class files will be put to `classes` folder, which is created if missing.
+   * `include` attribute - comma or space separated list of patterns of files that must be included.
+   * `exclude` attribute - comma or space separated list of pattersn of files that mus be excluded.
    * `package` attribute - name of the package of the CAP file. Optional for applets - set to the parent package of the applet class if left unspecified, required for libraries
    * `version` attribute - version of the package. Optional - defaults to 0.1 if left unspecified.
    * `fidesmoappid` attribute - [Fidesmo](https://developer.fidesmo.com) appId, to create the package AID and applet AID-s automatically. Optional.

--- a/src/main/java/pro/javacard/ant/JavaCard.java
+++ b/src/main/java/pro/javacard/ant/JavaCard.java
@@ -197,6 +197,8 @@ public final class JavaCard extends Task {
         private String classes_path = null;
         private String sources_path = null;
         private String sources2_path = null;
+        private String includes = null;
+        private String excludes = null;
         private String package_name = null;
         private byte[] package_aid = null;
         private String package_version = null;
@@ -259,6 +261,14 @@ public final class JavaCard extends Task {
 
         public void setSources2(String arg) {
             sources2_path = arg;
+        }
+
+        public void setIncludes(String arg) {
+        	includes = arg;
+        }
+
+        public void setExcludes(String arg) {
+        	excludes = arg;
         }
 
         public void setVerify(boolean arg) {
@@ -490,6 +500,11 @@ public final class JavaCard extends Task {
             if (sources2_path != null)
                 sources.append(new Path(project, sources2_path));
             j.setSrcdir(sources);
+
+			if (includes != null)
+	            j.setIncludes(includes);
+	        if (excludes != null)
+	            j.setExcludes(excludes);
 
             log("Compiling files from " + sources, Project.MSG_INFO);
 


### PR DESCRIPTION
This PR adds support for passing the javac `includes` and `excludes` attributes. This is useful for setups that might have two applets in one directory, for example with different applet main classes.

