### PR TITLE
Make strip option effective on library packages

### DIFF
--- a/src/main/java/pro/javacard/ant/JavaCard.java
+++ b/src/main/java/pro/javacard/ant/JavaCard.java
@@ -829,6 +829,30 @@ public final class JavaCard extends Task {
                                         }
                                     }
                                 });
+                            } else if (package_name != null) {                                
+                                // previous branch is good for applet. 
+                                // In case of a package, class files are located following their package name
+                                // for instance package testapplets.library; => testapplets\library\
+                                String path = package_name.replace(".", "/");
+                                Files.walkFileTree(zipfs.getPath(path), new SimpleFileVisitor<java.nio.file.Path>() {
+
+                                    @Override
+                                    public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs) throws IOException {
+                                        if (file.toString().endsWith(".class")) {
+                                            Files.delete(file);
+                                        }
+                                        return FileVisitResult.CONTINUE;
+                                    }
+ 
+                                    @Override
+                                    public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc) throws IOException {
+                                        if (exc == null) {
+                                            return FileVisitResult.CONTINUE;
+                                        } else {
+                                            throw exc;
+                                        }
+                                    }
+                                });
                             }
                         }
                     }

--- a/tests-11.xml
+++ b/tests-11.xml
@@ -52,8 +52,28 @@
   <!-- Library -->
   <target name="test-library" depends="jcpro">
     <javacard jckit="${JC305}">
-      <cap targetsdk="${JC222}" sources="src/testapplets/library" package="testapplets.library" aid="01020304050607" export="testlib" version="0.1"/>
+      <cap targetsdk="${JC222}" sources="src/testapplets/library" package="testapplets.library" aid="01020304050607" export="testlib" version="0.1" />
     </javacard>
+  </target>
+  <target name="test-library-strip" depends="jcpro">
+  	<sequential>
+      <javacard jckit="${JC305}">
+	      <cap targetsdk="${JC222}" sources="src/testapplets/library" package="testapplets.library" aid="01020304050607" export="testlib" version="0.1" 
+	           output="test.library-unstripped.cap"/>
+	  </javacard>
+  	  <javacard jckit="${JC305}">
+  		  <cap targetsdk="${JC222}" sources="src/testapplets/library" package="testapplets.library" aid="01020304050607" export="testlib" version="0.1" 
+  		       strip = "true" output="test.library-stripped.cap"/>
+  	  </javacard>
+  	  <length file="test.library-unstripped.cap" property="length.unstripped"/>
+  	  <length file="test.library-stripped.cap" property="length.stripped"/>
+  		<echo>length unstripped : ${length.unstripped}</echo>
+  		<echo>length   stripped : ${length.stripped}</echo>
+  		<condition property="bigger">
+  			<length file="test.library-stripped.cap" when="greater" length="${length.unstripped}"/>
+  		</condition>
+  		<fail if="bigger"/>
+  	</sequential>
   </target>
   <!-- JC 2.2.2 with 3.0.4 library -->
   <target name="test-library-user" depends="jcpro,test-library">


### PR DESCRIPTION
The strip option was not effective for library package (without applet defined).

Such cap file do not have "APPLET-INF/classes" directory.
class files are instead stored in a package name dependent directory.

A basic test was added within tests-11.xml

This MR hopefully fixes it.
