### PR TITLE
Add support for the exportmap flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Details:
    * `aid` attribute - AID (hex) of the package. Recommended - or set to the 5 first bytes of the applet AID if left unspecified.
    * `output` attribute - path where to save the generated CAP file. Optional, see below for variables.
    * `export` attribtue - path (folder) where to place the JAR and generated EXP file. Optional.
+   * `exportmap` attribtue - if set to true, use pre-defined export file. Optional.
    * `jar` attribute - path where to save the generated archive JAR file. Optional.
    * `jca` attribute - path where to save the generated JavaCard Assembly (JCA) file. Optional.
    * `verify` attribute - if set to false, disables verification of the resulting CAP file with offcardeverifier. Optional.

--- a/task/src/main/java/pro/javacard/ant/JCCap.java
+++ b/task/src/main/java/pro/javacard/ant/JCCap.java
@@ -47,6 +47,7 @@ public class JCCap extends Task {
     private boolean debug = false;
     private boolean strip = false;
     private boolean ints = false;
+    private boolean exportmap = false;
 
 
     public JCCap(String master_jckit_path) {
@@ -115,6 +116,10 @@ public class JCCap extends Task {
 
     public void setInts(boolean arg) {
         ints = arg;
+    }
+
+    public void setExportmap(boolean arg) {
+        exportmap = arg;
     }
 
     public void setTargetsdk(String arg) {
@@ -510,6 +515,9 @@ public class JCCap extends Task {
         if (ints) {
             j.createArg().setLine("-i");
         }
+        if (exportmap) {
+            j.createArg().setLine("-exportmap");
+	}
 
         // determine output types
         String outputs = "CAP";


### PR DESCRIPTION
This flag is esp. useful if you want to reimplement an existing package. E.g. you can use it to implement a missing javacardx.framework.tlv package.