### PR TITLE
add utf-8 encoding to javac for worldwide use.

### DIFF
--- a/task/src/main/java/pro/javacard/ant/JavaCard.java
+++ b/task/src/main/java/pro/javacard/ant/JavaCard.java
@@ -508,6 +508,7 @@ public final class JavaCard extends Task {
             // construct javac task
             Javac j = new Javac();
             j.setProject(project);
+            j.setEncoding("utf-8");
             j.setTaskName("compile");
 
             org.apache.tools.ant.types.Path sources = mkPath(null);


### PR DESCRIPTION
If we got a utf-8 java file which include some none English characters on a none utf-8 default environment, then ant build will fail.
Simply add a encoding property to Javac will fix it.

![image](https://github.com/martinpaljak/ant-javacard/assets/14291489/442c427c-7e54-4571-bfef-652a99095861)
