### PR TITLE
Implement support for Manifold Preprocessor

### DIFF
--- a/task/src/main/java/pro/javacard/ant/BuildProp.java
+++ b/task/src/main/java/pro/javacard/ant/BuildProp.java
@@ -1,0 +1,18 @@
+package pro.javacard.ant;
+
+public class BuildProp {
+    String key;
+    String value;
+
+    public BuildProp() {
+
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/task/src/main/java/pro/javacard/ant/BuildProp.java
+++ b/task/src/main/java/pro/javacard/ant/BuildProp.java
@@ -1,6 +1,12 @@
 package pro.javacard.ant;
 
+import org.apache.tools.ant.BuildException;
+
+import java.util.regex.Pattern;
+
 public class BuildProp {
+    static Pattern regex;
+
     String key;
     String value;
 
@@ -9,10 +15,18 @@ public class BuildProp {
     }
 
     public void setKey(String key) {
+        if (!regex.matcher(key).find()) {
+            throw new BuildException("The buildprop key contains illegal characters: " + key);
+        }
+
         this.key = key;
     }
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    static {
+        regex = Pattern.compile("^[a-zA-Z_][0-9a-zA-Z_]*$");
     }
 }


### PR DESCRIPTION
Hello!

There is a very cool project that appeared some time ago, called [Manifold Preprocessor](https://github.com/manifold-systems/manifold/tree/master/manifold-deps-parent/manifold-preprocessor). While it doesn't seem to have super huge significance for normal business Java applications, this might be a huge deal-breaker for JavaCard development.

It allows to use a C-style preprocessor within Java source files:
```
#if MODE_A
  out.println("MODE A");
#elif MODE_B
  out.println("MODE B");
#else
  #warning "No MODE defined, defaulting to MODE_C"
#endif
```

This pull request is a proposition to add support for Manifold Preprocessor within ant-javacard.

## Example usage

Include manifold-related JARs:
```
  <get src="https://repo1.maven.org/maven2/systems/manifold/manifold-preprocessor/2025.1.26/manifold-preprocessor-2025.1.26.jar" dest="lib" skipexisting="true" />
  <get src="https://repo1.maven.org/maven2/systems/manifold/manifold/2025.1.26/manifold-2025.1.26.jar" dest="lib" skipexisting="true" />
  <get src="https://repo1.maven.org/maven2/systems/manifold/manifold-rt/2025.1.26/manifold-rt-2025.1.26.jar" dest="lib" skipexisting="true" />
  <get src="https://repo1.maven.org/maven2/systems/manifold/manifold-util/2025.1.26/manifold-util-2025.1.26.jar" dest="lib" skipexisting="true" />
```

Define `manifoldpath` within `cap` tag (path to the directory that contains those JAR files) and some `<buildprop ... />` tags with the preprocessor variables to be defined:
```
  <target name="applet">
    <javacard jckit="sdk/jc320v25.0_kit">
      <cap
              targetsdk="3.0.4"
              output="MyApplet.cap"
              sources="${main.src.dir}"
              includes="com/example/myapplet/*.java"
              classes="${ant.classes.dir}"
              aid="F012345678"
              version="1.0"
              manifoldpath="lib/"
      >
        <applet class="com.example.myapplet.MyApplet" aid="F01234567800" />

        <!-- preprocessor variables provided here -->
        <buildprop key="MY_VARIABLE" value="1" />
        <buildprop key="SOME_OTHER_VAR" value="1" />
      </cap>
    </javacard>
  </target>
```

Build variables may also be provided through `build.properties` file in the project's top level directory.

Test that variables are applied or not applied when compiling the code (make sure to `clean` first, as caching may sometimes be too aggressive):

```
public void process(APDU apdu) {
    byte[] buf = apdu.getBuffer();
    byte cla = buf[ISO7816.OFFSET_CLA];
    byte ins = buf[ISO7816.OFFSET_INS];

    if (selectingApplet()) {
#if MY_VARIABLE
        ISOException.throwIt(SW_TERMINATED);
#endif
    }
    return;

    // ...
}
```